### PR TITLE
Regex Support for Words from Sensor Friendly Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ Example:
 
 ```yaml
 name_replace:
-  - pattern: ' ?your Text'
+  - pattern: your Text
+    flags: 'gi'
+    replace: 'your new Text'
+  - pattern: your Text 2
     flags: 'gi'
     replace: ''
 ```

--- a/README.md
+++ b/README.md
@@ -54,23 +54,6 @@ lovelace:
 | `show_icon`           | `boolean`  | `false`                     | Displays the entity icon if true.                                               |
 | `unit_position`       | `string`   | `"right"`                   | Position of unit label relative to value. Options: `"left"` or `"right"`.     |
 
-### name_replace (optional)
-Allows removing or replacing parts of the friendly name via regular expressions.
-- `string`: treated as pattern with flags `gi`, replacement `""`.
-- `object`: `{ pattern: string, flags?: string, replace?: string }`.
-
-Example:
-
-```yaml
-name_replace:
-  - pattern: your Text
-    flags: 'gi'
-    replace: 'your new Text'
-  - pattern: your Text 2
-    flags: 'gi'
-    replace: ''
-```
-
 ## Color Options
 
 | **Option**      | **Default**                       | **Description**                           |
@@ -276,6 +259,37 @@ You can also just list the entity ID for default behavior:
 ```
 
 ---
+
+## 🖊️ Regex Support for Entity Friendly Names 
+Allows removing or replacing parts of the friendly name via regular expressions.
+- `string`: treated as pattern with flags `gi`, replacement `""`.
+- `object`: `{ pattern: string, flags?: string, replace?: string }`.
+
+Example:
+
+```yaml
+name_replace:
+  - pattern: your Text
+    flags: 'gi'
+    replace: 'your new Text'
+  - pattern: your Text 2
+    flags: 'gi'
+    replace: ''
+```
+```yaml
+type: custom:strip-card
+entities:
+  - entity: sensor.smart_plug_living_room_power_consumption
+  - entity: sensor.smart_plug_kitchen_room_power_consumption
+  - entity: sensor.smart_plug_kids_room_power_consumption
+  - entity: sensor.smart_plug_garden_power_consumption
+  - entity: sensor.smart_plug_car_power_consumption
+name_replace:
+  - pattern: "sensor.smart_plug_"
+    replace: ""
+  - pattern: "_power_consumption"
+    replace: ""
+```
 
 ## ⚡ Tap to Call Action
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Example:
 
 ```yaml
 name_replace:
-  - pattern: ' ?Offener Betrag'
+  - pattern: ' ?your Text'
     flags: 'gi'
     replace: ''
 ```

--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ lovelace:
 | `show_icon`           | `boolean`  | `false`                     | Displays the entity icon if true.                                               |
 | `unit_position`       | `string`   | `"right"`                   | Position of unit label relative to value. Options: `"left"` or `"right"`.     |
 
+### name_replace (optional)
+Allows removing or replacing parts of the friendly name via regular expressions.
+- `string`: treated as pattern with flags `gi`, replacement `""`.
+- `object`: `{ pattern: string, flags?: string, replace?: string }`.
+
+Example:
+
+```yaml
+name_replace:
+  - pattern: ' ?Offener Betrag'
+    flags: 'gi'
+    replace: ''
+```
+
 ## Color Options
 
 | **Option**      | **Default**                       | **Description**                           |


### PR DESCRIPTION
Regex added (also see Readme) to remove/edit words from the friendly names of the sensors. Especially useful when using the Strip Card with Auto-Entities. For example, it changes “Sensor 1 Temperature” and “Sensor 2 Temperature” to “Sensor 1” and “Sensor 2.” It is also possible to add multiple regular expressions.

Example:
type: custom:strip-card
name_replace:
  - pattern: Temperature
    flags: gi
    replace: ""
name_replace:
  - pattern: Amount
    flags: gi
    replace: "your new word"
entities: []

This removes “Temperature” from all sensors and replaces "Amount" from all sensors with "your new word". Useful if sensors are not to be renamed otherwise.

Note: I can't program and “programmed” this with Codex. It should therefore definitely be checked again to see if it causes any problems before it is merged.
